### PR TITLE
chill out a bit on lockstep alignments

### DIFF
--- a/config/dlss_baseline.yml
+++ b/config/dlss_baseline.yml
@@ -90,6 +90,9 @@ Style/ClosingParenthesisIndentation:
 Style/Documentation:
   Enabled: false
 
+Style/EmptyLinesAroundBlockBody:
+  Enabled: false
+
 Style/EmptyLinesAroundClassBody:
   Enabled: false
 

--- a/config/dlss_baseline.yml
+++ b/config/dlss_baseline.yml
@@ -84,6 +84,9 @@ Style/BlockComments:
 Style/ClassAndModuleChildren:
   Enabled: false
 
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 

--- a/config/dlss_baseline.yml
+++ b/config/dlss_baseline.yml
@@ -102,6 +102,9 @@ Style/EmptyLinesAroundModuleBody:
 Style/ExtraSpacing:
   Enabled: false
 
+Style/IndentArray:
+  Enabled: false
+
 Style/LeadingCommentSpace:
   Enabled: false
 

--- a/config/dlss_baseline.yml
+++ b/config/dlss_baseline.yml
@@ -99,6 +99,9 @@ Style/EmptyLinesAroundClassBody:
 Style/EmptyLinesAroundModuleBody:
   Enabled: false
 
+Style/ExtraSpacing:
+  Enabled: false
+
 Style/LeadingCommentSpace:
   Enabled: false
 


### PR DESCRIPTION
@mjgiarlo 
- ClosingParenthesisIndentation:
  I like fairly consistent indentation, but I'm fine if the left paren is left on the first line ... and if it is, then fiddling around to line up the closing paren is really annoying.  This isn't the greatest example, but I'm ok with stuff like this:

``` ruby
      expect(result.to_xml).to be_equivalent_to(<<-EOF
        <fileGroupDifference groupId="content" differenceCount="3" identical="3" copyadded="0" copydeleted="0" renamed="0" modified="1" added="0" deleted="2">
          <subset change="identical" count="3">
         ...
      EOF
      )
```

more examples here:  https://github.com/sul-dlss/dor-services/blob/master/spec/datastreams/version_metadata_spec.rb#L95-L109
- EmptyLinesAroundBlockBody:
  I sometimes find it _easier_ to read code with empty lines around block body.  I wouldn't say it interferes with cognition when this is inconsistent.
- ExtraSpacing
  I am often in favor of sameline comments  being more than one space away from code; it makes it easier to read, IMO.   Again, I wouldn't say it interferes with cognition when this is allowed. 

``` ruby
       solr_doc[key] ||= []     # initialize multivalue targts if necessary
```
- IndentArray
  Again, while I'm in favor of fairly consistent indentation, something like this works fine for me:

``` ruby
      content_diff = @ng782rw8378_content_diff
      delete_list = get_delete_list(content_diff)
      expect(delete_list.map { |file| file[0, 2] }).to eq([
          [:deleted, 'SUB2_b2000_1.bvecs'],
          [:deleted, 'SUB2_b2000_1.bvals'],
          [:deleted, 'SUB2_b2000_1.nii.gz']] )
```

also this clear:  I can see what's in the array, where it starts, and where it ends without difficulty:

``` ruby
          expect(new_nodes.keys.sort). to eq([
              'folder1PuSu/story3m.txt',
              'folder1PuSu/story5a.txt',
              'folder2PdSa/story8m.txt',
              'folder2PdSa/storyAa.txt',
              'folder3PaSd/storyDm.txt',
              'folder3PaSd/storyFa.txt'
          ])
```
