### PR TITLE
rubocop update changes namespace from Style -> Layout on some cops

### DIFF
--- a/config/dlss_baseline.yml
+++ b/config/dlss_baseline.yml
@@ -25,6 +25,9 @@ Rails:
 
 # DLSS configuration changes for these cops enabled by default in Rubocop
 
+Layout/IndentationConsistency:
+  EnforcedStyle: rails
+
 Metrics/AbcSize:
   Max: 20
 
@@ -46,9 +49,6 @@ Metrics/ModuleLength:
 Style/IfUnlessModifier:
   MaxLineLength: 120
 
-Style/IndentationConsistency:
-  EnforcedStyle: rails
-
 Style/WhileUntilModifier:
   MaxLineLength: 120
 
@@ -64,13 +64,34 @@ RSpec/ExampleWording:
 # DLSS explicitly disabling these cops enabled by default in Rubocop
 # (DLSS agrees they should be disabled, or we disagree about whether they should be enabled)
 
-Style/AccessModifierIndentation:
+Layout/AccessModifierIndentation:
   Enabled: false
 
-Style/AlignHash:
+Layout/AlignHash:
   Enabled: false
 
-Style/AlignParameters:
+Layout/AlignParameters:
+  Enabled: false
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: false
+
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: false
+
+Layout/LeadingCommentSpace:
+  Enabled: false
+
+Layout/SpaceAfterNot:
+  Enabled: false
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: false
+
+Layout/SpaceInsideBrackets:
+  Enabled: false
+
+Layout/TrailingBlankLines:
   Enabled: false
 
 Style/AsciiComments:
@@ -85,15 +106,6 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
-Style/EmptyLinesAroundClassBody:
-  Enabled: false
-
-Style/EmptyLinesAroundModuleBody:
-  Enabled: false
-
-Style/LeadingCommentSpace:
-  Enabled: false
-
 Style/NegatedIf:
   Enabled: false
 
@@ -106,19 +118,7 @@ Style/RegexpLiteral:
 Style/SingleLineBlockParams:
   Enabled: false
 
-Style/SpaceAfterNot:
-  Enabled: false
-
-Style/SpaceAroundEqualsInParameterDefault:
-  Enabled: false
-
-Style/SpaceInsideBrackets:
-  Enabled: false
-
 Style/StringLiterals:
-  Enabled: false
-
-Style/TrailingBlankLines:
   Enabled: false
 
 Style/TrailingCommaInLiteral:


### PR DESCRIPTION
Fix #12

Updated the namespace for some cops and aimed to rearrange them alphabetically.

Not sure how to test this.